### PR TITLE
Add the python file command to the palette

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import '../style/index.css';
 
 const FACTORY = 'Editor';
 const ICON_CLASS = 'jp-PythonIcon';
-const PALETTE_CATEGORY = 'File Editor';
+const PALETTE_CATEGORY = 'Text Editor';
 
 namespace CommandIDs {
   export const createNew = 'fileeditor:create-new-python-file';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {
   JupyterLab, JupyterLabPlugin
 } from '@jupyterlab/application';
 
+import { ICommandPalette } from '@jupyterlab/apputils';
 import { ILauncher } from '@jupyterlab/launcher';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { IMainMenu } from '@jupyterlab/mainmenu';
@@ -10,6 +11,7 @@ import '../style/index.css';
 
 const FACTORY = 'Editor';
 const ICON_CLASS = 'jp-PythonIcon';
+const PALETTE_CATEGORY = 'File Editor';
 
 namespace CommandIDs {
   export const createNew = 'fileeditor:create-new-python-file';
@@ -24,19 +26,21 @@ const extension: JupyterLabPlugin<void> = {
   optional: [
     ILauncher,
     IMainMenu,
+    ICommandPalette,
   ],
   activate: (
     app: JupyterLab,
     browserFactory: IFileBrowserFactory,
     launcher: ILauncher,
-    menu: IMainMenu | null
+    menu: IMainMenu | null,
+    palette: ICommandPalette,
   ) => {
     const { commands } = app;
 
     commands.addCommand(CommandIDs.createNew, {
-      label: 'Python File',
+      label: args => (args['isPalette'] ? 'New Python File' : 'Python File'),
       caption: 'Create a new Python file',
-      iconClass: ICON_CLASS,
+      iconClass: args => (args['isPalette'] ? '' : ICON_CLASS),
       execute: args => {
         let cwd = args['cwd'] || browserFactory.defaultBrowser.model.path;
         return commands
@@ -54,6 +58,7 @@ const extension: JupyterLabPlugin<void> = {
       }
     });
 
+    // add to the launcher
     if (launcher) {
       launcher.add({
         command: CommandIDs.createNew,
@@ -61,6 +66,17 @@ const extension: JupyterLabPlugin<void> = {
         rank: 1
       });
     }
+
+    // add to the palette
+    if (palette) {
+      palette.addItem({
+        command: CommandIDs.createNew,
+        args: { isPalette: true},
+        category: PALETTE_CATEGORY
+      });
+    }
+
+    // add to the menu
     menu.fileMenu.newMenu.addGroup([{ command: CommandIDs.createNew }], 30);
 
     console.log("JupyterLab extension jupyterlab-python-file is activated!");


### PR DESCRIPTION
So new Python files can be created via the command palette.

![image](https://user-images.githubusercontent.com/591645/48151749-61f85e80-e2c2-11e8-8e9f-f45e4a189662.png)

