### PR TITLE
Update Binder setup for JupyterLab 3

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,7 +1,0 @@
-name: jupyterlab-python-file
-channels:
-- conda-forge
-dependencies:
-- jupyterlab=2
-- python=3
-

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,0 @@
-jupyter labextension install jupyterlab-python-file


### PR DESCRIPTION
No need for specific Binder files anymore, as `repo2docker` also supports `setup.py`.