### PR TITLE
Add context menu entry

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "target": "es2017",
     "types": []
   },


### PR DESCRIPTION
Fixes #24 

Also move `IFileBrowserFactory` to `optional` to make the plugin more flexible. 

![image](https://user-images.githubusercontent.com/591645/101768824-649f9080-3ae6-11eb-9525-5de33e7f089c.png)
