### PR TITLE
Automated Changelog Entry for 0.5.3 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.5.3
+
+([Full Changelog](https://github.com/jtpio/jupyterlab-python-file/compare/0.5.2...baeb9b7efe84ee65ea263bcd9efe9591c1d3263c))
+
+### Merged PRs
+
+- Make the package importable [#41](https://github.com/jtpio/jupyterlab-python-file/pull/41) ([@jtpio](https://github.com/jtpio))
+- Add Releaser hooks [#38](https://github.com/jtpio/jupyterlab-python-file/pull/38) ([@jtpio](https://github.com/jtpio))
+- Prepare repo to adopt the Jupyter Releaser [#35](https://github.com/jtpio/jupyterlab-python-file/pull/35) ([@jtpio](https://github.com/jtpio))
+- Bump postcss from 7.0.34 to 7.0.36 [#34](https://github.com/jtpio/jupyterlab-python-file/pull/34) ([@dependabot](https://github.com/dependabot))
+- Bump glob-parent from 5.1.1 to 5.1.2 [#33](https://github.com/jtpio/jupyterlab-python-file/pull/33) ([@dependabot](https://github.com/dependabot))
+- Bump ws from 7.3.1 to 7.4.6 [#32](https://github.com/jtpio/jupyterlab-python-file/pull/32) ([@dependabot](https://github.com/dependabot))
+- Bump lodash from 4.17.20 to 4.17.21 [#31](https://github.com/jtpio/jupyterlab-python-file/pull/31) ([@dependabot](https://github.com/dependabot))
+- Bump hosted-git-info from 2.8.8 to 2.8.9 [#30](https://github.com/jtpio/jupyterlab-python-file/pull/30) ([@dependabot](https://github.com/dependabot))
+- Bump y18n from 4.0.0 to 4.0.1 [#29](https://github.com/jtpio/jupyterlab-python-file/pull/29) ([@dependabot](https://github.com/dependabot))
+- Bump ssri from 8.0.0 to 8.0.1 [#28](https://github.com/jtpio/jupyterlab-python-file/pull/28) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-python-file/graphs/contributors?from=2020-12-16&to=2021-06-21&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-python-file+involves%3Adependabot+updated%3A2020-12-16..2021-06-21&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-python-file+involves%3Ajtpio+updated%3A2020-12-16..2021-06-21&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.5.2
 
 - Add `install.json` to provide more information about the extension: https://github.com/jtpio/jupyterlab-python-file/pull/27
@@ -12,5 +37,3 @@ JupyterLab v3.0.0rc13
 /home/username/miniforge3/envs/jupyterlab-python-file/share/jupyter/labextensions
         jupyterlab-python-file v0.5.1 enabled OK (python, jupyterlab-python-file)
 ```
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.5.3 on main
Python version: 0.5.3
npm version: jupyterlab-python-file: 0.5.2

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jtpio/jupyterlab-python-file  |
| Branch  | main  |
| Version Spec | 0.5.3 |
